### PR TITLE
Add test for Client Work text visibility

### DIFF
--- a/tests/client_work_visibility.spec.ts
+++ b/tests/client_work_visibility.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test('Verify Client Work text visibility', async ({ page }) => {
+  // Navigate to EPAM homepage
+  await page.goto('https://www.epam.com/');
+
+  // Navigate directly to the Services page
+  await page.goto('https://www.epam.com/services');
+
+  // Click on "Explore Our Client Work" link
+  await page.getByRole('link', { name: 'Explore Our Client Work' }).click();
+
+  // Ensure "Client Work" text is visible
+  await expect(page.locator('text=Client Work')).toBeVisible();
+
+  // Close the browser
+  await page.close();
+});


### PR DESCRIPTION
This test verifies that the "Client Work" text is visible after navigating through the Services page and clicking on the "Explore Our Client Work" link.