### PR TITLE
Add test for Client Work text visibility

### DIFF
--- a/tests/clientWorkVisibility.spec.ts
+++ b/tests/clientWorkVisibility.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test('Verify Client Work text visibility on Epam website', async ({ page }) => {
+  // Navigate to the Epam website
+  await page.goto('https://www.epam.com/');
+
+  // Click on "Services" from the header
+  await page.click('header >> text=Services');
+
+  // Click on "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+
+  // Ensure that "Client Work" text is visible
+  const clientWorkText = await page.isVisible('text=Client Work');
+  expect(clientWorkText).toBeTruthy();
+
+  // Close the browser
+  await page.context().browser()?.close();
+});


### PR DESCRIPTION
This PR adds a Playwright test to verify the visibility of the 'Client Work' text on the Epam website. The test navigates to the website, selects 'Services' from the header, clicks on 'Explore Our Client Work' link, and ensures that the 'Client Work' text is visible.